### PR TITLE
small tweaks to results page

### DIFF
--- a/src/main/java/com/vik/covid19vik/MainController.java
+++ b/src/main/java/com/vik/covid19vik/MainController.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
@@ -130,8 +131,8 @@ class MainController {
             countryDataTable[1] = caseInfo[1];
             model.addAttribute("graphNewConf", graphNewConf);
             model.addAttribute("graphTotalConf", graphTotalConf);
-            model.addAttribute("recentNewConf", recentNewConf);
-            model.addAttribute("recentTotalConf", recentTotalConf);
+            model.addAttribute("recentNewConf", NumberFormat.getNumberInstance(Locale.US).format(recentNewConf));
+            model.addAttribute("recentTotalConf", NumberFormat.getNumberInstance(Locale.US).format(recentTotalConf));
         } else {
             System.out.println("Could not get confirmed series data");
         }
@@ -151,8 +152,8 @@ class MainController {
             countryDataTable[3] = caseInfo[1];
             model.addAttribute("graphNewDeaths", graphNewDeaths);
             model.addAttribute("graphTotalDeaths", graphTotalDeaths);
-            model.addAttribute("recentNewDeaths", recentNewDeaths);
-            model.addAttribute("recentTotalDeaths", recentTotalDeaths);
+            model.addAttribute("recentNewDeaths", NumberFormat.getNumberInstance(Locale.US).format(recentNewDeaths));
+            model.addAttribute("recentTotalDeaths", NumberFormat.getNumberInstance(Locale.US).format(recentTotalDeaths));
         } else {
             System.out.println("Could not get deaths series data");
         }
@@ -172,8 +173,8 @@ class MainController {
             countryDataTable[5] = caseInfo[1];
             model.addAttribute("graphNewRecovs", graphNewRecovs);
             model.addAttribute("graphTotalRecovs", graphTotalRecovs);
-            model.addAttribute("recentNewRecov", recentNewRecov);
-            model.addAttribute("recentTotalRecov", recentTotalRecov);
+            model.addAttribute("recentNewRecov", NumberFormat.getNumberInstance(Locale.US).format(recentNewRecov));
+            model.addAttribute("recentTotalRecov", NumberFormat.getNumberInstance(Locale.US).format(recentTotalRecov));
         } else {
             System.out.println("Could not get recovered series data");
         }
@@ -219,7 +220,7 @@ class MainController {
         if (fips != -1) {
             model.addAttribute("fips", fips);
         }
-        model.addAttribute("population", population);
+        model.addAttribute("population", NumberFormat.getNumberInstance(Locale.US).format(population));
         model.addAttribute("currentURL", req.getRequestURL() + "?" + req.getQueryString());
         return "results";
     }

--- a/src/main/resources/fragments/plotpoints.html
+++ b/src/main/resources/fragments/plotpoints.html
@@ -71,36 +71,6 @@
 		                itemclick: toggleDataVisible
 	            },
                 data: [{
-                    name: "Total Confirmed Cases",
-                    showInLegend: true,
-                    connectNullData: true,
-                    yValueFormatString: "###,###,###",
-                    xValueType: "dateTime",
-                    xValueFormatString: "DD-MM-YY",
-                    type: "line",
-                    dataPoints: totalConf
-                },
-                {
-                    name: "Total Fatal Cases",
-                    showInLegend: true,
-                    connectNullData: true,
-                    yValueFormatString: "###,###,###",
-                    xValueType: "dateTime",
-                    xValueFormatString: "DD-MM-YY",
-                    type: "line",
-                    dataPoints: totalDeaths
-                },
-                {
-                    name: "Total Recovered Cases",
-                    showInLegend: true,
-                    connectNullData: true,
-                    yValueFormatString: "###,###,###",
-                    xValueType: "dateTime",
-                    xValueFormatString: "DD-MM-YY",
-                    type: "line",
-                    dataPoints: totalRecovs
-                },
-                {
                     name: "New Confirmed Cases",
                     showInLegend: true,
                     connectNullData: true,
@@ -112,7 +82,7 @@
                     dataPoints: newConf
                 },
                 {
-                    name: "New Fatal Cases",
+                    name: "New Deaths",
                     showInLegend: true,
                     connectNullData: true,
                     yValueFormatString: "###,###,###",
@@ -123,7 +93,7 @@
                     dataPoints: newDeaths
                 },
                 {
-                    name: "New Recovered Cases",
+                    name: "New Recoveries",
                     showInLegend: true,
                     connectNullData: true,
                     yValueFormatString: "###,###,###",

--- a/src/main/resources/fragments/plotpoints.html
+++ b/src/main/resources/fragments/plotpoints.html
@@ -36,7 +36,7 @@
                 zoomEnabled: true,
                 theme: "light2",
                 title: {
-                    text: "Time Series Data"
+                    text: "New Cases, Deaths, and Recoveries"
                 },
                 subtitles: [{
                     text: searchedName

--- a/src/main/resources/fragments/plotpoints.html
+++ b/src/main/resources/fragments/plotpoints.html
@@ -77,6 +77,7 @@
                     xValueFormatString: "DD-MM-YY",
                     type: "line",
                     lineDashType: "dash",
+                    color: "blue",
                     dataPoints: newConf
                 },
                 {
@@ -88,6 +89,7 @@
                     xValueFormatString: "DD-MM-YY",
                     type: "line",
                     lineDashType: "dash",
+                    color: "red",
                     dataPoints: newDeaths
                 },
                 {
@@ -99,6 +101,7 @@
                     xValueFormatString: "DD-MM-YY",
                     type: "line",
                     lineDashType: "dash",
+                    color: "green",
                     dataPoints: newRecovs
                 }]
             };

--- a/src/main/resources/fragments/plotpoints.html
+++ b/src/main/resources/fragments/plotpoints.html
@@ -42,13 +42,11 @@
                     text: searchedName
                 }],
                 axisX: {
-                    title: "Dates",
                     valueFormatString: "MM/DD/YY",
                     intervalType: "day",
                     labelAngle: -20
                 },
                 axisY: {
-                    title: "Cases",
                     logarithmic: false,
                     interlacedColor: "#F0F8FF",
                 },

--- a/src/main/resources/templates/results.html
+++ b/src/main/resources/templates/results.html
@@ -56,7 +56,7 @@
                     <section class="card statCard">
                         <article class="card-body">
                             <!-- overall stats -->
-                            <h1 class="resultsHeaders totalsProgression display-4">Totals</h1>
+                            <h1 class="resultsHeaders totalsProgression display-4">Cumulative Totals</h1>
                             <p class="lead" th:if="${searchedCountry == 'US'} and ${searchedProvince}">Recovery data for the US by state/county level is unavailable.</p>
                             <p class="lead" th:if="${searchedCountry == 'Canada'} and ${searchedProvince}">Recovery data for Canadian provinces is unavailable.</p>
                             <div class="container">

--- a/src/main/resources/templates/results.html
+++ b/src/main/resources/templates/results.html
@@ -66,7 +66,6 @@
                                             <h4 class="card-title">Cases Confirmed</h4>
                                             <th:block th:unless="${recentTotalConf == null} and ${recentNewConf == null}">
                                                 <p class="lead" th:text="'Total: ' + ${recentTotalConf}"></p>
-                                                <p class="lead" th:text="'New: ' + ${recentNewConf}"></p>
                                             </th:block>
                                             <th:block th:if="${recentTotalConf == null} and ${recentNewConf == null}">
                                                 <p class="lead">Unavailable</p>
@@ -78,7 +77,6 @@
                                             <h4 class="card-title">Fatal Cases</h4>
                                             <th:block th:unless="${recentTotalDeaths == null} and ${recentNewDeaths == null}">
                                                 <p class="lead" th:text="'Total: ' + ${recentTotalDeaths}"></p>
-                                                <p class="lead" th:text="'New: ' + ${recentNewDeaths}"></p>
                                             </th:block>
                                             <th:block th:if="${recentTotalDeaths == null} and ${recentNewDeaths == null}">
                                                 <p class="lead">Unavailable</p>
@@ -90,7 +88,6 @@
                                             <h4 class="card-title">Cases Recovered</h4>
                                             <th:block th:unless="${recentTotalRecov == null} and ${recentNewRecov == null}">
                                                 <p class="lead" th:text="'Total: ' + ${recentTotalRecov}"></p>
-                                                <p class="lead" th:text="'New: ' + ${recentNewRecov}"></p>
                                             </th:block>
                                             <th:block th:if="${recentTotalRecov == null} and ${recentNewRecov == null}">
                                                 <p class="lead">Unavailable</p>


### PR DESCRIPTION
Hey Vik, this is just a start.  I'd still like to work on making interactive comparisons by age bracket and geographic area like we discussed, in addition to smoothing out the daily noise by displaying average weekly counts as well.  As I was digging into what you've done (which is so impressive), I spotted some small tweaks that could help clarify the data a little bit and draw out the trends in the time series data, so I'm submitting a pull request with just those tweaks.  Feel free to incorporate or ignore whatever you like!  
<img width="1280" alt="Screen Shot 2020-05-07 at 11 44 57 AM" src="https://user-images.githubusercontent.com/31393715/81333385-650c1080-9059-11ea-8e77-c03a7d5a2913.png">
